### PR TITLE
Add .gitignore note to README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -19,6 +19,8 @@ This plugin enables Publish (on your) Own Site, Syndicate Elsewhere (POSSE) func
 1. Download or clone this repository to `/site/plugins/posse`
 2. Configure the plugin through the Panel at "POSSE > Settings"
 
+Optiojnal: Add `/site/db/posse.sqlite` and `/site/config/posse.yml` to `.gitignore` for git-based deployment strategies.
+
 ## Configuration
 
 Everything related to the plugin can be configured through the Kirby Panel. The automated syndication feature requires Basic Auth to be enabled in your config.php:


### PR DESCRIPTION
There isn’t one way of deploying in the Kirby community, but there is a fairly big amount of devs using git-based deployments like myself. Therefore I added the DB and config file to `.gitignore`, so that it doesn’t override the settings or database on the production server. Adding a note for these kind of setups might be helpful here.